### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mohamadfitriadin/ec11fb52-4fc2-4989-8a20-54e91c132e77/ff4ba44e-bae3-4ae0-bce2-43743fadc992/_apis/work/boardbadge/f48d536e-3985-493c-af71-f8f4b4f228bb)](https://dev.azure.com/mohamadfitriadin/ec11fb52-4fc2-4989-8a20-54e91c132e77/_boards/board/t/ff4ba44e-bae3-4ae0-bce2-43743fadc992/Microsoft.RequirementCategory)
 # go_basic
 Learn GoLang
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/mohamadfitriadin/ec11fb52-4fc2-4989-8a20-54e91c132e77/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.